### PR TITLE
Update .gitignore to remove docs/Gemfile.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ Templates/*/bin/
 Templates/*/obj/
 Logshark.CLI.Installer.Bundle/Contents/
 Tableau.RestApi/GeneratedCode/*.cs
+docs/Gemfile.lock


### PR DESCRIPTION
And prevent the vulnerability warnings because dependencies are out-of-date.