### PR TITLE
Adding legal and privacy links to footer

### DIFF
--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -2,7 +2,8 @@
 <footer>
     <div class="row">
         <hr class="footer-hr">
-        <p>This site is open source. Suggestions and pull requests are welcome on our <a href="https://github.com/tableau/Logshark">GitHub page</a>.</p>
-        <p>&copy; 2017 Tableau.</p>
+        <p>This site is open source. Suggestions and pull requests are welcome on our <a href="https://github.com/tableau/Logshark">GitHub page</a>.</p>       
+            <p><a href="https://www.tableau.com/en-us/legal" class="aLegal">LEGAL</a> <a href="https://www.tableau.com/en-us/privacy" class="aLegal">PRIVACY</a> &copy; 2003&ndash;<script>document.write(new Date().getFullYear())</script> TABLEAU SOFTWARE LLC. ALL RIGHTS RESERVED</p>
+            <sub>Documentation last generated on: {{ site.time }}</sub>
     </div>
 </footer>

--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -374,3 +374,9 @@ a.bg-primary:focus {
     padding-left: 1.5em;
     list-style-type: none;
 }
+
+/* Legal and Privacy Links */
+.aLegal  {
+    word-spacing:  8px;
+    padding-right: 8px;
+}


### PR DESCRIPTION
@bermetj  Hi, I don't have write access to the repo. We need to make an update to the footer in the documentation. We're making this change in all our Tableau GitHub content that we host in GitHub Pages.  If you could merge this to `development` and then `master` that would be great. Thanks, Dave 

Doc update: 
- For GDPR compliance, adding links to the Tableau legal and privacy pages
- Updating styles and formatting to match other Tableau content