### PR TITLE
Add optional pid to regex expression for java log files for 2024.2

### DIFF
--- a/LogShark/Plugins/Backgrounder/BackgrounderEventParser.cs
+++ b/LogShark/Plugins/Backgrounder/BackgrounderEventParser.cs
@@ -37,9 +37,11 @@ namespace LogShark.Plugins.Backgrounder
         private static readonly Regex NewBackgrounderRegex =
             // 10.4+
             // 10.4 added "job type" and 10.5 added "local request id", either of which may be empty and thus are marked optional here
+            // 2024.2 added optional "pid" to match 2024.2, and made ts_offset more exclusionary
             new Regex(@"^
                             (?<ts>\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}.\d{3})
-                            \s(?<ts_offset>[^\s]+)
+                            \s(?<ts_offset>[-|+]\d+?)
+                            \s?(?<pid>\d+)?
                             \s\((?<site>[^,]*), (?<user>[^,]*), (?<data_sess_id>[^,]*), (?<vql_sess_id>[^,]*), (?<job_id>[^,]*), :?(?<job_type>[^,]*) ,(?<local_req_id>[^\s]*)\)
                             \s?(?<module>[^\s]*)?
                             \s(?<thread>[^\s]*)

--- a/LogShark/Plugins/ClusterController/ClusterControllerPlugin.cs
+++ b/LogShark/Plugins/ClusterController/ClusterControllerPlugin.cs
@@ -213,9 +213,11 @@ namespace LogShark.Plugins.ClusterController
         private IWriter<ZookeeperError> _zkErrorWriter;
         private IWriter<ZookeeperFsyncLatency> _zkFsyncLatencyWriter;
 
+        // 2024.2 added optional "pid" to match 2024.2
         private static readonly Regex _clusterControllerLogsRegex = new Regex(@"^
             (?<ts>\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}.\d{3})\s
             (?<ts_offset>.+?)\s
+            ?(?<pid>\d+)?\s
             (?<thread>.*?)\s
             (?<sev>[A-Z]+)(\s+)
             :\s
@@ -245,6 +247,7 @@ namespace LogShark.Plugins.ClusterController
         private static readonly Regex _zookeeperRegex = new Regex(@"^
             (?<ts>\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}.\d{3})\s
             (?<ts_offset>.+?)\s
+            ?(?<pid>\d+)?\s
             (?<thread>.*?)\s
             :\s
             (?<sev>[A-Z]+)(\s+)

--- a/LogShark/Plugins/Filestore/FilestorePlugin.cs
+++ b/LogShark/Plugins/Filestore/FilestorePlugin.cs
@@ -20,11 +20,12 @@ namespace LogShark.Plugins.Filestore
 
         private IWriter<FilestoreEvent> _writer;
         private IProcessingNotificationsCollector _processingNotificationsCollector;
-
+        // 2024.2 added optional "pid" to match 2024.2
         private readonly Regex _regex = 
             new Regex(@"^
                         (?<ts>\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}.\d{3})\s
                         (?<ts_offset>.+?)\s
+                        ?(?<pid>\d+)?\s
                         (?<thread>.*?)\s+
                         (?<sev>[A-Z]+)(\s+)
                         :\s

--- a/LogShark/Plugins/SearchServer/SearchServerPlugin.cs
+++ b/LogShark/Plugins/SearchServer/SearchServerPlugin.cs
@@ -15,9 +15,11 @@ namespace LogShark.Plugins.SearchServer
         private IWriter<SearchServerEvent> _writer;
         private IProcessingNotificationsCollector _processingNotificationsCollector;
 
+        // 2024.2 added optional "pid" to match 2024.2
         private readonly Regex _regex = new Regex(@"^
             (?<ts>\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}.\d{3})\s
             (?<ts_offset>.+?)\s
+            ?(?<pid>\d+)?\s
             \((?<site>.*?), (?<user>.*?), (?<sess>.*?), (?<req>.*?)\)\s
             (?<thread>.*?)\s
             :\s

--- a/LogShark/Plugins/SharedRegex.cs
+++ b/LogShark/Plugins/SharedRegex.cs
@@ -4,9 +4,11 @@ namespace LogShark.Plugins
 {
     public static class SharedRegex
     {
+        // 2024.2 added optional "pid" to match 2024.2, and made ts_offset more exclusionary
         public static readonly Regex JavaLogLineRegex = new Regex(@"^
             (?<ts>\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}.\d{3})\s
-            (?<ts_offset>[^\s]+?)\s
+            (?<ts_offset>[-|+]\d+)\s
+            ?(?<pid>\d+)?\s
             \((?<site>[^,]*?), (?<user>[^,]*?), (?<sess>[^,]*?), (?<req>[^,\)]*?) (,(?<local_req_id>[^\)]*?))?\)\s
             (?<thread>[^\s]*?)\s
              (?<service>[^:]*?)?:\s


### PR DESCRIPTION
Fix for #178 .

In 2024.2 java logs, a new id is added directly following ts_offset. Regex is adjusted to optionally pull in id (assumed to be PID) and successfully parse 2024.2+ logs.