### PR TITLE
@gus W-17274770 Add Cookie Manager and links

### DIFF
--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -1,9 +1,20 @@
 <!-- Footer -->
 <footer>
-    <div class="row">
-        <hr class="footer-hr">
-        <p>This site is open source. Suggestions and pull requests are welcome on our <a href="https://github.com/tableau/Logshark">GitHub page</a>.</p>
-        <p><a href="https://www.tableau.com/en-us/legal" class="aLegal">LEGAL</a> <a href="https://www.tableau.com/en-us/privacy" class="aLegal">PRIVACY</a> &copy; 2003&ndash;<script>document.write(new Date().getFullYear())</script> TABLEAU SOFTWARE LLC. ALL RIGHTS RESERVED</p>
-        <sub>Documentation last generated on: {{ site.time }}</sub>
-    </div>
-</footer>
+    <hr class="footer-hr">
+    <nav aria-label="Footer Navigation">
+        <ul class="footer-links">
+            <li><a href="https://www.salesforce.com/company/legal/">Legal</a></li>
+            <li><a href="https://www.salesforce.com/company/legal/sfdc-website-terms-of-service/">Terms of Service</a></li>
+            <li><a href="https://www.salesforce.com/company/privacy/">Privacy Information</a></li>
+            <li><a href="https://www.salesforce.com/company/legal/disclosure/">Responsible Disclosure</a></li>
+            <li><a href="https://trust.salesforce.com/">Trust</a></li>
+            <li><a href="#" data-ignore-geolocation="true" class="optanon-toggle-display">Cookie Preferences</a></li>
+            <li><a href="https://www.salesforce.com/form/other/privacy-request/">Your Privacy Choices</a></li>
+        </ul>
+        <p class="copyRight">This site is open source. Suggestions and pull requests are welcome on our <a href="https://github.com/tableau/Logshark">GitHub page</a>.</p>
+        <p class="copyRight">&copy; Copyright <script>document.write(new Date().getFullYear())</script> Salesforce, Inc. <a href="https://www.salesforce.com/company/legal/tmcusageguidelines/">All rights reserved.</a> Various trademarks held by their respective owners.
+            Salesforce, Inc. Salesforce Tower, 415 Mission Street, 3rd Floor, San Francisco, CA 94105, United States</p>
+        <sub>Documentation last generated on: {{ site.time }}</sub></p>
+    </nav>
+  </footer>
+  

--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -11,6 +11,13 @@
   <link rel="stylesheet" href="{{ site.baseurl }}/css/main.css">
   <link rel="stylesheet" href="{{ site.baseurl }}/css/github-highlight.css">
 
+  <!-- OneTrust Cookies Consent Notice start for tableau.github.io -->
+  <script src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js"  type="text/javascript" charset="UTF-8" data-domain-script="019321c1-4b7e-7313-9372-ddbd938f50ea" ></script>
+  <script type="text/javascript">
+    function OptanonWrapper() { }
+  </script>
+  <!-- OneTrust Cookies Consent Notice end for tableau.github.io -->
+
   <script src="{{ site.baseurl }}/js/redirect-to-search.js"></script>
   <script src="https://code.jquery.com/jquery-2.2.4.min.js"></script>
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js"></script>

--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -380,3 +380,41 @@ a.bg-primary:focus {
     word-spacing:  8px;
     padding-right: 8px;
 }
+
+
+.copyRight {
+    font-size: 12px;
+  }
+  
+  .footer-links {
+    display: flex;
+    justify-content: center; 
+    list-style: none;
+    padding: 0; 
+    flex-wrap: wrap;
+  }
+  
+  .footer-links li {
+    margin: 0 15px; 
+  }
+  
+  .footer-links a {
+    text-decoration: none;
+    transition: color 0.3s;
+    font-size: 12px;
+  }
+  
+  .footer-links a:hover {
+    text-decoration: underline;
+  }
+  
+  /* One Trust Cookie Manager
+  -------------------- */
+  #ot-pc-content, .ot-title-cntr, .ot-pc-footer {
+    font-size: 1.6rem;
+  }
+  
+  #ot-pc-footer {
+    font-size: 1.4rem;
+  }
+  


### PR DESCRIPTION
Adding the OneTrust Cookie Manager to be in compliance with SFDC guidelines and be able to collect Google Analytics data (page views, usage).

* Add Cookie manager (Cookie Preferences in footer)
* Add OneTrust script to page head.html
* Update footer with correct links and formatting
